### PR TITLE
장판 버그 수정

### DIFF
--- a/BeatSlimeClient/Assets/Scenes/JY/EffectManager.cs
+++ b/BeatSlimeClient/Assets/Scenes/JY/EffectManager.cs
@@ -30,7 +30,7 @@ public class EffectManager : MonoBehaviour
 
         GameObject go = Instantiate(TileEffectPrefab, GameManager.data.grid.cellMaps.Get(start_x, start_y, start_z).getCellRealPosition(), Quaternion.identity);
         float s = speed * 1 / 1000f;
-        //Debug.Log(s);
+        Debug.Log("effect " + Time.time);
         go.GetComponent<TileEffect>().speed = s;
     }
 

--- a/BeatSlimeClient/Assets/Scenes/JY/TileEffect.cs
+++ b/BeatSlimeClient/Assets/Scenes/JY/TileEffect.cs
@@ -22,7 +22,7 @@ public class TileEffect : MonoBehaviour
         float scale = 0.0f;
         while(scale <= 1.0f)
         {
-            scale += Time.deltaTime *1/speed ; 
+            scale += Time.deltaTime *1 / speed ; 
             gameObject.transform.localScale = new Vector3(scale, 0.01f, scale);
             yield return null;
         }

--- a/BeatSlimeClient/Assets/Scripts/GameManager.cs
+++ b/BeatSlimeClient/Assets/Scripts/GameManager.cs
@@ -231,8 +231,9 @@ public class GameManager : MonoBehaviour
                             //enemy.GetComponent<EnemyManager>().BeatPatternServe(nowBeat, new Beat(0, randomTickForTest), Objects[target_id]);
                             //Objects[target_id].GetComponent<PlayerManager>().SetBallBeat(nowBeat, new Beat(0, randomTickForTest));
                             //Debug.Log("ServerID_To_ClientID : " + p.target_id+ " to " + target_id);
-                            
+                      
                             HPManager hm = Objects[target_id].GetComponent<PlayerManager>().HP;
+                            Debug.Log("ID : " + p.target_id + "damage : " + (hm.CurrentHP - p.hp));
                             hm.Damage(hm.CurrentHP - p.hp);
                         }
                         break;

--- a/BeatSlimeClient/Assets/Scripts/Omnipresent/HPManager.cs
+++ b/BeatSlimeClient/Assets/Scripts/Omnipresent/HPManager.cs
@@ -30,7 +30,7 @@ public class HPManager
     public void Damage(int damage)
     {
         CurrentHP -= damage;
-        Debug.Log("Damaged");
+        //Debug.Log("Damaged");
         if (CurrentHP <= 0)
             isAlive = false;
     }

--- a/BeatSlimeServer/Server/Server/Network.h
+++ b/BeatSlimeServer/Server/Server/Network.h
@@ -89,8 +89,8 @@ public:
 	}
 	bool is_attack(int a, int x, int z)
 	{
-		if (ATTACK_RANGE < abs(clients[a]->x - x)) return false;
-		if (ATTACK_RANGE < abs(clients[a]->z - z)) return false;
+		if (abs(clients[a]->x != x)) return false;
+		if (abs(clients[a]->z != z)) return false;
 
 		return true;
 	}


### PR DESCRIPTION
장판 주변에서 데미지를 받는 버그 수정

			// 현재 해당 위치에 있지 않는데 데미지를 받음
			// 버그가 나는 이유
			//	- 플레이어의 위치 업데이트가 느린경우
			//		-> 움직임이 클라이언트에 보인다는건 이미 서버에서 처리가 끝나고 패킷까지 전송했다는 뜻 즉 해당 경우는 발생할 수 없음
			//	- 클라이언트에서 계산해 보여지는 이펙트와 서버에서 계산해 피격하는 시간이 맞지 않는 경우
			//		-> 장판이 커지는 시간을 서버에서 전송해주는데 그럴 수 없지
			//		-> 클라이언트에서 프레임시간에 스피드 곱해서 스케일을 조정
			//		-> 서버에서 보내주는 시간 -> millisec 그래서 클라이언트에서 계산할 때 sec로 바꿈
			//		-> 약간의 차이로 피한경우 데미지가 들어온다
			//		- 클라이언트와 서버간 장판 차징 시간 차이
			//			- 서버
			//				-> 계산된 시간(A)만큼 뒤에 이벤트 큐에서 빼서 attack패킷만 보내면 됨
			//				-> 이벤트 큐에서 빼는 시간만큼의 차이가 생김
			//			- 클라
			//				-> 장판 차징을 보여주기 위해 시작과 장판이 커지는 시간(A)을 서버로부터 받음
			//				-> 패킷을 받는 시간 + 이펙트를 생성하는 시간만큼의 차이가 생김
			//			* 이 두 시간다 무시해도될 거 같은데
			//			커지면 들어오는건 맞음
			//	* 위의 문제들은 다 아니고
			//
			//	- 정확한 위치 계산이 안되고 있는거 같네요